### PR TITLE
Use resize-observer-polyfill where ResizeObserver is unavailable

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-react": "^7.12.4",
     "jest": "^24.7.1",
     "node-sass": "^4.11.0",
+    "resize-observer-polyfill": "^1.5.1",
     "rimraf": "^2.6.2",
     "webpack": "^4.30.0",
     "webpack-cli": "^3.3.0",


### PR DESCRIPTION
RO is powerful, but not implemented in all browsers. This polyfill (or [ponyfill](https://github.com/sindresorhus/ponyfill), more technically) will implement the required functionality in browsers down to IE9.